### PR TITLE
Add optional Unbound DNS resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Example add-on configuration:
   "ipv4_address": "",
   "ipv6_address": "",
   "virtual_host": "homeassistant.example.com",
+  "use_unbound_resolver": true,
+  "unbound_port": 5353,
   "hosts": [
     {
       "name": "printer.local",
@@ -224,6 +226,15 @@ be a short style hostname like: `printer` or a longer one `printer.local`.
 
 The IP address this specified host must point to. Its value must be an IPv6 or
 IPv4 IP address.
+
+### Option: `use_unbound_resolver`
+
+Enables in-built [Unbound](https://nlnetlabs.nl/projects/unbound/about/) DNS resolver. When enabled, you should configure
+your upstream DNS to point to 127.0.0.1#unbound_port (see below)
+
+### Option: `unbound_port`
+
+Port to use internally for communicating with Unbound DNS resolver.
 
 ### Option: `i_like_to_be_pwned`
 

--- a/pi-hole/Dockerfile
+++ b/pi-hole/Dockerfile
@@ -54,6 +54,8 @@ RUN \
         sed=4.4-r2 \
         sudo=1.8.23-r2 \
         wget=1.20.1-r0 \
+        unbound=1.7.3-r0 \
+        jq=1.6_rc1-r1 \
     \
     && addgroup -S pihole \
     && adduser -S -s /sbin/nologin pihole pihole \
@@ -92,6 +94,9 @@ RUN \
 
 # Copy root filesystem
 COPY rootfs /
+
+# Download the current root hints file (the list of primary root servers which are serving the domain "." - the root domain). 
+RUN wget -O /etc/unbound/root.hints https://www.internic.net/domain/named.root
 
 # Build arguments
 ARG BUILD_ARCH

--- a/pi-hole/config.json
+++ b/pi-hole/config.json
@@ -37,7 +37,10 @@
     "ipv4_address": "",
     "ipv6_address": "",
     "virtual_host": "",
+    "use_unbound_resolver": false,
+    "unbound_port": 5353,
     "hosts": []
+    
   },
   "schema": {
     "log_level": "match(^(trace|debug|info|notice|warning|error|fatal)$)",
@@ -53,6 +56,7 @@
     "ipv4_address": "str",
     "ipv6_address": "str",
     "virtual_host": "str",
+    "use_unbound_resolver": "bool",
     "hosts": [
       {
         "name": "str",
@@ -60,7 +64,8 @@
       }
     ],
     "i_like_to_be_pwned": "bool?",
-    "leave_front_door_open": "bool?"
+    "leave_front_door_open": "bool?",
+    "unbound_port": "int?"
   },
   "environment": {
     "LOG_FORMAT": "{LEVEL}: {MESSAGE}"

--- a/pi-hole/rootfs/etc/cont-init.d/37-unbound.sh
+++ b/pi-hole/rootfs/etc/cont-init.d/37-unbound.sh
@@ -9,4 +9,5 @@ source /usr/lib/hassio-addons/base.sh
 if hass.config.has_value 'use_unbound_resolver'; then
     hass.log.debug 'Enabling unbound service'
     unbound_port=$(hass.config.get 'unbound_port')
-    sed -i 's/port: 5353/port: $unbound_port/g' /etc/unbound/unbound.conf
+    sed -i 's/port: 5353/port: '"$unbound_port"'/g' /etc/unbound/unbound.conf
+fi

--- a/pi-hole/rootfs/etc/cont-init.d/37-unbound.sh
+++ b/pi-hole/rootfs/etc/cont-init.d/37-unbound.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/with-contenv bash
+# ==============================================================================
+# Community Hass.io Add-ons: Pi-hole
+# Adds custom configured hosts to the DNS resolver
+# ==============================================================================
+# shellcheck disable=SC1091
+source /usr/lib/hassio-addons/base.sh
+
+if hass.config.has_value 'use_unbound_resolver'; then
+    hass.log.debug 'Enabling unbound service'
+    unbound_port=$(hass.config.get 'unbound_port')
+    sed -i 's/port: 5353/port: $unbound_port/g' /etc/unbound/unbound.conf

--- a/pi-hole/rootfs/etc/cron.d/unbound
+++ b/pi-hole/rootfs/etc/cron.d/unbound
@@ -1,0 +1,6 @@
+# Unbound: A validating, recursive, and caching DNS resolver. 
+# https://nlnetlabs.nl/projects/unbound/about/
+# https://github.com/NLnetLabs/unbound
+
+# Update root server hints update every 3 months at 3am on the 1st of the month
+0 3 1 */3 * wget -O /etc/unbound/root.hints https://www.internic.net/domain/named.root && service unbound restart

--- a/pi-hole/rootfs/etc/services.d/unbound/finish
+++ b/pi-hole/rootfs/etc/services.d/unbound/finish
@@ -1,0 +1,9 @@
+#!/usr/bin/execlineb -S0
+# ==============================================================================
+# Community Hass.io Add-ons: Pi-hole
+# Take down the S6 supervision tree when PHP FPM fails
+# ==============================================================================
+if -n { s6-test $# -ne 0 }
+if -n { s6-test ${1} -eq 256 }
+
+s6-svscanctl -t /var/run/s6/services

--- a/pi-hole/rootfs/etc/services.d/unbound/run
+++ b/pi-hole/rootfs/etc/services.d/unbound/run
@@ -1,0 +1,9 @@
+#!/usr/bin/with-contenv bash
+# ==============================================================================
+# Community Hass.io Add-ons: Pi-hole
+# Runs the PHP-FPM daemon
+# ==============================================================================
+# shellcheck disable=SC1091
+source /usr/lib/hassio-addons/base.sh
+
+exec unbound -v -d

--- a/pi-hole/rootfs/etc/services.d/unbound/run
+++ b/pi-hole/rootfs/etc/services.d/unbound/run
@@ -6,4 +6,8 @@
 # shellcheck disable=SC1091
 source /usr/lib/hassio-addons/base.sh
 
-exec unbound -v -d
+if hass.config.true 'use_unbound_resolver'; then
+    unbound_port=$(hass.config.get 'unbound_port')
+    hass.log.debug "Starting Unbound DNS resolver on port ${unbound_port}"
+    exec unbound -v -d
+fi

--- a/pi-hole/rootfs/etc/unbound/unbound.conf
+++ b/pi-hole/rootfs/etc/unbound/unbound.conf
@@ -8,7 +8,6 @@ server:
     do-ip4: yes
     do-udp: yes
     do-tcp: yes
-    access-control: 0.0.0.0/0 allow
 
     # May be set to yes if you have IPv6 connectivity
     do-ip6: no

--- a/pi-hole/rootfs/etc/unbound/unbound.conf
+++ b/pi-hole/rootfs/etc/unbound/unbound.conf
@@ -1,0 +1,53 @@
+# This config was borrowed from: https://docs.pi-hole.net/guides/unbound/
+server:
+    # If no logfile is specified, syslog is used
+    # logfile: "/var/log/unbound/unbound.log"
+    verbosity: 0
+
+    port: 5353
+    do-ip4: yes
+    do-udp: yes
+    do-tcp: yes
+    access-control: 0.0.0.0/0 allow
+
+    # May be set to yes if you have IPv6 connectivity
+    do-ip6: no
+
+    # Use this only when you downloaded the list of primary root servers!
+    root-hints: "/etc/unbound/root.hints"
+
+    # Trust glue only if it is within the servers authority
+    harden-glue: yes
+
+    # Require DNSSEC data for trust-anchored zones, if such data is absent, the zone becomes BOGUS
+    harden-dnssec-stripped: yes
+
+    # Don't use Capitalization randomization as it known to cause DNSSEC issues sometimes
+    # see https://discourse.pi-hole.net/t/unbound-stubby-or-dnscrypt-proxy/9378 for further details
+    use-caps-for-id: no
+
+    # Reduce EDNS reassembly buffer size.
+    # Suggested by the unbound man page to reduce fragmentation reassembly problems
+    edns-buffer-size: 1472
+
+    # TTL bounds for cache
+    cache-min-ttl: 3600
+    cache-max-ttl: 86400
+
+    # Perform prefetching of close to expired message cache entries
+    # This only applies to domains that have been frequently queried
+    prefetch: yes
+
+    # One thread should be sufficient, can be increased on beefy machines
+    num-threads: 1
+
+    # Ensure kernel buffer is large enough to not loose messages in traffic spikes
+    so-rcvbuf: 1m
+
+    # Ensure privacy of local IP ranges
+    private-address: 192.168.0.0/16
+    private-address: 169.254.0.0/16
+    private-address: 172.16.0.0/12
+    private-address: 10.0.0.0/8
+    private-address: fd00::/8
+    private-address: fe80::/10


### PR DESCRIPTION
# Proposed Changes

Adding 2 new options to the addon:

1.  `use_unbound_resolver`: defaults to `false`, enables and runs an Unbound DNS resolver in the container
2.  `unbound_port`: defaults to `5353`,  customize the port that the resolver listens on internally

I have been seeing more and more interest lately in people wanting to run their own recursive DNS resolvers in order to cut out 3rd parties (and to use DNSSEC), so this is a nice turn-key solution as far as I can tell. I can considered making Unbound into it's own addon, and that might still be a good solution, but it seems that it made sense to locate it with Pi-hole since it would only be used by Pi-hole (almost like a dependency).

I followed the Pi-hole docs [here](https://docs.pi-hole.net/guides/unbound/) for creating this configuration.

**Note:** the user will still need to specify their custom resolver in their Pi-hole admin config (eg, `127.0.0.1#5353`), I wasn't immediately aware of how to pre-load the chosen upstream DNS servers, or if that was even a good idea.

## Related Issues

[https://github.com/hassio-addons/addon-pi-hole/issues/66](https://github.com/hassio-addons/addon-pi-hole/issues/66)