### PR TITLE
Fixing pi-holes ability to clear logs from the database

### DIFF
--- a/pi-hole/Dockerfile
+++ b/pi-hole/Dockerfile
@@ -52,6 +52,7 @@ RUN \
         procps=3.3.15-r0 \
         psmisc=23.1-r0 \
         sed=4.4-r2 \
+        sqlite-3.25.3-r0 \
         sudo=1.8.23-r2 \
         wget=1.20.1-r0 \
     \

--- a/pi-hole/rootfs/etc/cont-init.d/35-logfiles.sh
+++ b/pi-hole/rootfs/etc/cont-init.d/35-logfiles.sh
@@ -8,6 +8,9 @@ source /usr/lib/hassio-addons/base.sh
 
 mkdir -p /data/log
 
+# Fix the permissions on the logrotate script so logs get cleared
+chmod 644 /etc/logrotate.d/pihole
+
 if ! hass.file_exists '/data/log/pihole.log'; then
     touch /data/log/pihole.log
     chmod 644 /data/log/pihole.log


### PR DESCRIPTION
# Proposed Changes

> adding the sqllite package, and changing the permissions of the logrotate/pihole script to allow for the standardized clearing of logs. The changes are pretty straight forward. I was trying to find the best place to do the chmod on the container init, and figured I would put it with the rest of the log scripts. If you know of a better place we can change it

## Related Issues

> https://github.com/hassio-addons/addon-pi-hole/issues/56

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/