### PR TITLE
Updated to latest Core, FTL, and Web tags.

### DIFF
--- a/pi-hole/Dockerfile
+++ b/pi-hole/Dockerfile
@@ -6,9 +6,9 @@ FROM ${BUILD_FROM}
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV PATH="${PATH}:/opt/pihole" \
-    CORE_TAG="v4.2.2" \
-    WEB_TAG="v4.2" \
-    FTL_TAG="v4.2.3"
+    CORE_TAG="v4.3" \
+    WEB_TAG="v4.3" \
+    FTL_TAG="v4.3"
 
 # We need to copy in the patches need during build
 COPY rootfs/patches /patches


### PR DESCRIPTION
# Proposed Changes

Pi-Hole version 4.3 is now the current release for each package and I would like to see these updated in the Hass.io add-on.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/