### PR TITLE
⬆️ Upgrades Pi-hole core to v4.3.2

### DIFF
--- a/pi-hole/Dockerfile
+++ b/pi-hole/Dockerfile
@@ -6,7 +6,7 @@ FROM ${BUILD_FROM}
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV PATH="${PATH}:/opt/pihole" \
-    CORE_TAG="v4.3.1" \
+    CORE_TAG="v4.3.2" \
     WEB_TAG="v4.3" \
     FTL_TAG="v4.3.1"
 


### PR DESCRIPTION
# Proposed Changes

Upgrade Pi-hole core to https://github.com/pi-hole/pi-hole/releases/tag/v4.3.2.

<blockquote><img src="https://repository-images.githubusercontent.com/20619036/d86b7900-610a-11e9-811b-100767c1714e" width="48" align="right"><div><img src="https://github.githubassets.com/favicon.ico" height="14"> GitHub</div><div><strong><a href="https://github.com/pi-hole/pi-hole">pi-hole/pi-hole</a></strong></div><div>A black hole for Internet advertisements. Contribute to pi-hole/pi-hole development by creating an account on GitHub.</div></blockquote>