### PR TITLE
Improve integration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,12 +188,12 @@ password empty.
 **Note**: _We STRONGLY suggest, not to use this, even if this add-on is
 only exposed to your internal network. USE AT YOUR OWN RISK!_
 
-## Using the Pi-hole sensor in Home Assistant
+## Using the Pi-hole integration in Home Assistant
 
-Home Assistant offers a [Pi-hole sensor][pi-hole-sensor] that allows you to
-display the statistical summary of your Pi-hole installation.
+Home Assistant offers a [Pi-hole integration][pi-hole-integration] that allows you to
+retrieve statistics and interact with your Pi-hole installation.
 
-To enable this sensor, add the following lines to your `configuration.yaml`
+To enable this integration, add the following lines to your `configuration.yaml`
 file:
 
 ```yaml


### PR DESCRIPTION
# Proposed Changes

Improves the documentation on HA integration. PR #102 missed some things. The integration is not only a sensor but also provides some services. https://www.home-assistant.io/integrations/pi_hole#services

<blockquote><img src="https://www.home-assistant.io/images/default-social.png" width="48" align="right"><div><img src="/images/favicon-192x192.png" height="14"> Home Assistant</div><div><strong><a href="https://www.home-assistant.io/integrations/pi_hole/">Pi-hole</a></strong></div><div>Instructions on how to integrate Pi-hole with Home Assistant.</div></blockquote>