### PR TITLE
🔨Add access control to api.conf

### DIFF
--- a/pi-hole/rootfs/etc/nginx/servers/api.disabled
+++ b/pi-hole/rootfs/etc/nginx/servers/api.disabled
@@ -4,6 +4,9 @@ server {
 
     root /var/www/html/;
 
+    allow   127.0.0.1;
+    deny all;
+
     location / {
         deny all;
     }


### PR DESCRIPTION
# Proposed Changes

With the Ingress implementation, the auth was removed, which in turn removes authentication from the API.  Adds access control to 127.0.0.1 (which HA will show as) to ensure the integration still functions.

May be worth considering making this configurable in the use case of controlling Pi-Hole external to HA?

## Related Issues

None